### PR TITLE
Updated build status badge for appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pre-release builds are published to [Harmony MyGet gallery.](https://www.myget.o
 
 ## Status
 
-[![Build status](https://ci.appveyor.com/api/projects/status/6k43rh3bd1kj2rk1?svg=true)](https://ci.appveyor.com/project/MagicTrevor/harmony)
+[![Build status](https://ci.appveyor.com/api/projects/status/github/MagicTrevor/Harmony?svg=true)](https://ci.appveyor.com/project/MagicTrevor/harmony)
 
 |    | Version |
 |:---|--------:|


### PR DESCRIPTION
The badge status was not working properly so it was updated to a more clear url.